### PR TITLE
System.Text.Json for .NET Standard 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ FluentHttpClient is optimized for .NET 10 and the newest .NET releases, while al
 
 Projects targeting **.NETStandard 2.0** or **.NETStandard 2.1** do not include `System.Text.Json` in the framework. FluentHttpClient uses `System.Text.Json` internally for its JSON extensions, but the package is not referenced transitively.
 
-If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference with a minimum version of 6.0.10 (a higher version is always recommended):
-
-```xml
-<PackageReference Include="System.Text.Json" Version="6.0.10" />
-```
+If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference, with a minimum version of 4.6.0 or 6.0.10, respectively. A higher version is always recommended.
 
 Apps targeting modern TFMs (such as .NET 5 and later) already include `System.Text.Json` and do not require this step.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,11 +26,7 @@ FluentHttpClient is optimized for .NET 10 and the newest .NET releases, while al
 
 Projects targeting **.NETStandard 2.0** or **.NETStandard 2.1** do not include `System.Text.Json` in the framework. FluentHttpClient uses `System.Text.Json` internally for its JSON extensions, but the package is not referenced transitively.
 
-If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference with a minimum version of 6.0.10 (a higher version is always recommended):
-
-```xml
-<PackageReference Include="System.Text.Json" Version="6.0.10" />
-```
+If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference, with a minimum version of 4.6.0 or 6.0.10, respectively. A higher version is always recommended.
 
 Apps targeting modern TFMs (such as .NET 5 and later) already include `System.Text.Json` and do not require this step.
 

--- a/src/FluentHttpClient/FluentHttpClient.csproj
+++ b/src/FluentHttpClient/FluentHttpClient.csproj
@@ -35,8 +35,13 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="6.0.10" PrivateAssets="All" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="[4.6.0,)" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="[4.7.2,)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="[6.0.10,)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluentHttpClient/FluentJsonSerializer.cs
+++ b/src/FluentHttpClient/FluentJsonSerializer.cs
@@ -15,7 +15,9 @@ internal static class FluentJsonSerializer
     public static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new JsonSerializerOptions
     {
         PropertyNameCaseInsensitive = true,
+#if NETSTANDARD2_1_OR_GREATER
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+#endif
     };
 }

--- a/src/FluentHttpClient/README.md
+++ b/src/FluentHttpClient/README.md
@@ -21,11 +21,7 @@ FluentHttpClient is optimized for .NET 10 and the newest .NET releases, while al
 
 Projects targeting **.NETStandard 2.0** or **.NETStandard 2.1** do not include `System.Text.Json` in the framework. FluentHttpClient uses `System.Text.Json` internally for its JSON extensions, but the package is not referenced transitively.
 
-If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference with a minimum version of 6.0.10 (a higher version is always recommended):
-
-```xml
-<PackageReference Include="System.Text.Json" Version="6.0.10" />
-```
+If you are building against **netstandard2.0** or **netstandard2.1**, or any TFM that does **not** ship `System.Text.Json`, you will need to add an explicit package reference, with a minimum version of 4.6.0 or 6.0.10, respectively. A higher version is always recommended.
 
 Apps targeting modern TFMs (such as .NET 5 and later) already include `System.Text.Json` and do not require this step.
 

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Changes the soft-dependency versions for .NET Standard 2.0:
- `System.Text.Json` from 6.0.10 to to 4.6.0
- `System.Text.Encodings.Web` to 4.7.2

Keeps `System.Text.Json` for .NET Standard 2.1 at 6.0.10.